### PR TITLE
Railites 5.0 + jsonb fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     activeadmin_json_editor (0.0.6)
       ace-rails-ap
-      railties (>= 3.0, < 5.0)
+      railties (>= 3.0, < 5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/activeadmin_json_editor.gemspec
+++ b/activeadmin_json_editor.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = '>= 1.3.6'
   spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_dependency 'railties', '>= 3.0', '< 5.0'
+  spec.add_dependency 'railties', '>= 3.0', '< 5.1'
   # spec.add_development_dependency "rake", "~> 0"
   # spec.add_dependency "active_admin", "~> 1.0.0"
   spec.add_dependency 'ace-rails-ap'

--- a/lib/activeadmin/resource_dsl.rb
+++ b/lib/activeadmin/resource_dsl.rb
@@ -7,7 +7,7 @@ module ActiveAdmin
       before_save do |object, _args|
         request_namespace = object.class.name.underscore.tr('/', '_')
         if params.key? request_namespace
-          object.class.columns_hash.select { |_key, attr| attr.type == :json }.keys.each do |key|
+          object.class.columns_hash.select { |_key, attr| attr.type.in? [:json, :jsonb] }.keys.each do |key|
             next unless params[request_namespace].key? key
             json_data = params[request_namespace][key]
             data = if json_data == 'null' || json_data.blank?


### PR DESCRIPTION
Hello,
I've made two changes:
1. Rails 5 requires railites ==5.0.0 and causes a conflict with your current gem dependencies which specify railties (>= 3.0, < 5.0). I have tested with 5.0.0 and things work fine.
2. The newest postgres releases support a jsonb type which has some awesome advantages https://www.postgresql.org/docs/9.4/static/datatype-json.html. 
   Your current code makes jsonb into an escaped string instead of storing an object. I've fixed this as well.
